### PR TITLE
Upgrade to nuke 5.1.0

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-source/UnwantedMethodCallsAnalyzer.sln

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Build Schema",
+  "$ref": "#/definitions/build",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "AppVeyor",
+            "AzurePipelines",
+            "Bamboo",
+            "Bitrise",
+            "GitHubActions",
+            "GitLab",
+            "Jenkins",
+            "SpaceAutomation",
+            "TeamCity",
+            "Terminal",
+            "TravisCI"
+          ]
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CalculateVersion",
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "Pack",
+              "Restore",
+              "Test"
+            ]
+          }
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CalculateVersion",
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "Pack",
+              "Restore",
+              "Test"
+            ]
+          }
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "source/UnwantedMethodCallsAnalyzer.sln"
+}

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,7 @@
 :; set -eo pipefail
-:; ./build.sh "$@"
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -14,10 +14,10 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 ###########################################################################
 
 $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
-$TempDirectory = "$PSScriptRoot\\.tmp"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
-$DotNetInstallUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "Current"
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1

--- a/build.sh
+++ b/build.sh
@@ -10,10 +10,10 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.tmp"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
-DOTNET_INSTALL_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="Current"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -3,8 +3,9 @@ using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
-using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Utilities.Collections;
+using Nuke.OctoVersion;
+using OctoVersion.Core;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
@@ -17,7 +18,7 @@ class Build : NukeBuild
 
     [Solution] readonly Solution Solution;
 
-    GitVersion GitVersion;
+    [NukeOctoVersion] readonly OctoVersionInfo OctoVersionInfo;
 
     AbsolutePath SourceDirectory => RootDirectory / "source";
     AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
@@ -41,13 +42,7 @@ class Build : NukeBuild
     Target CalculateVersion => _ => _
         .Executes(() =>
         {
-            GitVersion = GitVersionTasks
-                .GitVersion(s => s
-                    .SetTargetPath(".")
-                    .SetNoFetch(true)
-                    .SetFramework("netcoreapp3.0")
-                )
-                .Result;
+            //all the magic happens inside `[NukeOctoVersion]` above. we just need a target for TeamCity to call
         });
 
     Target Compile => _ => _
@@ -56,15 +51,14 @@ class Build : NukeBuild
         .DependsOn(Restore)
         .Executes(() =>
         {
-            Logger.Info("Building Octopus.UnwantedMethodCallsAnalyzer v{0}", GitVersion.FullSemVer);
-            Logger.Info("Informational Version {0}", GitVersion.InformationalVersion);
+            Logger.Info("Building Octopus.UnwantedMethodCallsAnalyzer v{0}", OctoVersionInfo.FullSemVer);
+            Logger.Info("Informational Version {0}", OctoVersionInfo.InformationalVersion);
 
             DotNetBuild(_ => _
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
-                .SetAssemblyVersion(GitVersion.AssemblySemVer)
-                .SetFileVersion(GitVersion.AssemblySemFileVer)
-                .SetInformationalVersion(GitVersion.InformationalVersion)
+                .SetVersion(OctoVersionInfo.FullSemVer)
+                .SetInformationalVersion(OctoVersionInfo.InformationalVersion)
                 .EnableNoRestore());
         });
 
@@ -92,26 +86,23 @@ class Build : NukeBuild
                 .SetConfiguration(Configuration)
                 .SetOutputDirectory(ArtifactsDirectory)
                 .SetNoBuild(true)
-                .AddProperty("Version", GitVersion.FullSemVer)
+                .AddProperty("Version", OctoVersionInfo.FullSemVer)
             );
         });
 
     Target CopyToLocalPackages => _ => _
         .OnlyWhenStatic(() => IsLocalBuild)
-        .DependsOn(Pack)
+        .TriggeredBy(Pack)
         .Executes(() =>
         {
             EnsureExistingDirectory(LocalPackagesDirectory);
-            CopyFileToDirectory(ArtifactsDirectory / $"Octopus.UnwantedMethodCallsAnalyzer.{GitVersion.FullSemVer}.nupkg", LocalPackagesDirectory, FileExistsPolicy.Overwrite);
+            CopyFileToDirectory(ArtifactsDirectory / $"Octopus.UnwantedMethodCallsAnalyzer.{OctoVersionInfo.FullSemVer}.nupkg", LocalPackagesDirectory, FileExistsPolicy.Overwrite);
         });
-
-    Target Default => _ => _
-        .DependsOn(CopyToLocalPackages);
 
     /// Support plugins are available for:
     /// - JetBrains ReSharper        https://nuke.build/resharper
     /// - JetBrains Rider            https://nuke.build/rider
     /// - Microsoft VisualStudio     https://nuke.build/visualstudio
     /// - Microsoft VSCode           https://nuke.build/vscode
-    public static int Main() => Execute<Build>(x => x.Default);
+    public static int Main() => Execute<Build>(x => x.Pack);
 }

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,15 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="0.24.11" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.1.1]" />
+    <PackageReference Include="Nuke.Common" Version="5.1.0" />
+    <PackageReference Include="Nuke.OctoVersion" Version="0.2.453" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\.gitignore">
+      <Link>config\.gitignore</Link>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.104",
+    "rollForward": "latestFeature"
+  }
+}

--- a/source/UnwantedMethodCallsAnalyzer.sln
+++ b/source/UnwantedMethodCallsAnalyzer.sln
@@ -23,13 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{06CE9746-01A4-41
 		..\readme.md = ..\readme.md
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{54B3DEDC-9D11-4D9F-BCE2-8A6CE55774D8}"
-ProjectSection(SolutionItems) = preProject
-	..\build\.editorconfig = ..\build\.editorconfig
-	..\build\_build.csproj = ..\build\_build.csproj
-	..\build\_build.csproj.DotSettings = ..\build\_build.csproj.DotSettings
-	..\build\Build.cs = ..\build\Build.cs
-EndProjectSection
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "_build", "..\build\_build.csproj", "{11F65C01-844E-4217-8A38-C60EF299AEFE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +39,8 @@ Global
 		{8F6A719A-C9EA-4836-80B9-A8FAD870031E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F6A719A-C9EA-4836-80B9-A8FAD870031E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F6A719A-C9EA-4836-80B9-A8FAD870031E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11F65C01-844E-4217-8A38-C60EF299AEFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11F65C01-844E-4217-8A38-C60EF299AEFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We [upgraded](https://github.com/OctopusDeploy/tool-containers/pull/25) the base build image to install the latest nuke.globaltool (version 5.1.0).
Nuke 5.1.0 [includes a new version](https://github.com/nuke-build/nuke/commit/bef28aab33d202688f67f527f7692b360ba93fa4) of GitVersion.Tool.
This meant we [had to update](https://github.com/OctopusDeploy/tool-containers/pull/25/files#diff-3dc3767944d5097e69dbc20d45548730bb43dfdbde1be7edfdb4140a66c6cfa1R58) the path (`LD_LIBRARY_PATH`) to the new native tool binaries.
Unfortunately this meant that while new stuff will build, old stuff will not.

As a quick fix, we are updating all projects to nuke 5.1.0 while we ponder the proper fix.