### PR TITLE
Revert to netstandand2.0 to fix IDE integration

### DIFF
--- a/source/UnwantedMethodCallsAnalyzer/UnwantedMethodCallsAnalyzer.csproj
+++ b/source/UnwantedMethodCallsAnalyzer/UnwantedMethodCallsAnalyzer.csproj
@@ -12,7 +12,7 @@
     <NoWarn>RS2008</NoWarn>
     <LangVersion>8</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Octopus Deploy Roslyn analyzers</Description>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>

--- a/source/UnwantedMethodCallsAnalyzer/UnwantedMethodCallsAnalyzerAnalyzer.cs
+++ b/source/UnwantedMethodCallsAnalyzer/UnwantedMethodCallsAnalyzerAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Octopus.UnwantedMethodCallsAnalyzer
             if (unwantedMethodsCache.Any())
                 context.RegisterSyntaxNodeAction(CheckUnwantedMethodCalls, SyntaxKind.InvocationExpression);
 
-            unwantedMethodNames = unwantedMethodsCache.Select(m => m.MethodName).ToHashSet();
+            unwantedMethodNames = new HashSet<string>(unwantedMethodsCache.Select(m => m.MethodName));
         }
 
         void CheckUnwantedMethodCalls(SyntaxNodeAnalysisContext context)


### PR DESCRIPTION
Under VS2022 the analyzer cannot be invoked and builds in the IDE fail with: 

```plaintext
An instance of analyzer Octopus.UnwantedMethodCallsAnalyzer.UnwantedMethodCallAnalyzer cannot be created...
Exception has been thrown by the target of an invocation
```

Reverting to `netstandard2.0` seems required and matches a similar move in [Nevermore.Analyzers](https://github.com/OctopusDeploy/Nevermore/commit/2fba3ccb90b5dcb71c56ecccdcb3e808f71c66e0).

